### PR TITLE
Fix hooks

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -57,7 +57,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     uint256 internal constant _MIN_PRICE_RATIO_UPDATE_DURATION = 1 days;
     uint256 internal immutable _MAX_DAILY_PRICE_RATIO_UPDATE_RATE;
 
-    uint256 internal constant _MIN_PRICE_RATIO = 1.0001e18; // 0.1%
+    uint256 internal constant _MIN_PRICE_RATIO = 1.0001e18; // 0.01%
 
     // There is also a minimum delta, to keep the math well-behaved.
     uint256 internal constant _MIN_PRICE_RATIO_DELTA = 1e6;

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -287,12 +287,16 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     /// @inheritdoc IHooks
     function onRegister(
         address,
-        address,
+        address pool,
         TokenConfig[] memory tokenConfig,
         LiquidityManagement calldata liquidityManagement
-    ) public pure override returns (bool) {
-        // This function is `pure`, so it does not need `onlyVault` protection.
+    ) public view override returns (bool) {
+        // This function is `view`, so it does not need `onlyVault` protection.
+        // Only returns `true` if invoked for this pool. This is important to prevent malicious pools from
+        // registering these hooks, which gives them access to state modifying functions
+        // (`onBeforeInitialize`, `onBeforeAddLiquidity`, and `onBeforeRemoveLiquidity`).
         return
+            pool == address(this) &&
             tokenConfig.length == 2 &&
             liquidityManagement.disableUnbalancedLiquidity &&
             liquidityManagement.enableDonation == false;
@@ -303,6 +307,13 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         uint256[] memory balancesScaled18,
         bytes memory
     ) public override onlyVault returns (bool) {
+        // There is no `pool` argument, but given that `onRegister` only allows this contract to register these hooks
+        // for itself, `onlyVault` is sufficient. On the other hand, there is no reason to call this function
+        // more than once, so we ensure that locally.
+        if (_vault.isPoolInitialized(address(this))) {
+            revert PoolAlreadyInitialized();
+        }
+
         (uint256 virtualBalanceA, uint256 virtualBalanceB, uint256 priceRatio) = _helper
             .computeInitialVirtualBalancesAndRatio(balancesScaled18);
 
@@ -326,6 +337,12 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         uint256[] memory balancesScaled18,
         bytes memory
     ) public override onlyVault returns (bool) {
+        // `onlyVault` is sufficient, but in any case this code should only be executed when the Vault calls this
+        // function with the correct pool address.
+        if (pool != address(this)) {
+            revert InvalidPoolArgument(pool);
+        }
+
         // This hook makes sure that the virtual balances are increased in the same proportion as the real balances
         // after adding liquidity. This is needed to keep the pool centeredness and price ratio constant.
 
@@ -355,6 +372,12 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         uint256[] memory balancesScaled18,
         bytes memory
     ) public override onlyVault returns (bool) {
+        // `onlyVault` is sufficient, but in any case this code should only be executed when the Vault calls this
+        // function with the correct pool address.
+        if (pool != address(this)) {
+            revert InvalidPoolArgument(pool);
+        }
+
         // This hook makes sure that the virtual balances are decreased in the same proportion as the real balances
         // after removing liquidity. This is needed to keep the pool centeredness and price ratio constant.
 

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -339,9 +339,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     ) public override onlyVault returns (bool) {
         // `onlyVault` is sufficient, but in any case this code should only be executed when the Vault calls this
         // function with the correct pool address.
-        if (pool != address(this)) {
-            revert InvalidPoolArgument(pool);
-        }
+        require(pool == address(this), InvalidPoolArgument(pool));
 
         // This hook makes sure that the virtual balances are increased in the same proportion as the real balances
         // after adding liquidity. This is needed to keep the pool centeredness and price ratio constant.
@@ -374,9 +372,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     ) public override onlyVault returns (bool) {
         // `onlyVault` is sufficient, but in any case this code should only be executed when the Vault calls this
         // function with the correct pool address.
-        if (pool != address(this)) {
-            revert InvalidPoolArgument(pool);
-        }
+        require(pool == address(this), InvalidPoolArgument(pool));
 
         // This hook makes sure that the virtual balances are decreased in the same proportion as the real balances
         // after removing liquidity. This is needed to keep the pool centeredness and price ratio constant.

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -57,6 +57,8 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     uint256 internal constant _MIN_PRICE_RATIO_UPDATE_DURATION = 1 days;
     uint256 internal immutable _MAX_DAILY_PRICE_RATIO_UPDATE_RATE;
 
+    uint256 internal constant _MIN_PRICE_RATIO = 1.0001e18; // 0.1%
+
     // There is also a minimum delta, to keep the math well-behaved.
     uint256 internal constant _MIN_PRICE_RATIO_DELTA = 1e6;
 
@@ -573,6 +575,10 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         onlySwapFeeManagerOrGovernance(address(this))
         returns (uint256 actualPriceRatioUpdateStartTime)
     {
+        if (endPriceRatio < _MIN_PRICE_RATIO) {
+            revert EndPriceRatioBelowMin(endPriceRatio);
+        }
+
         actualPriceRatioUpdateStartTime = GradualValueChange.resolveStartTime(
             priceRatioUpdateStartTime,
             priceRatioUpdateEndTime

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -112,6 +112,9 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     uint128 internal _lastVirtualBalanceA;
     uint128 internal _lastVirtualBalanceB;
 
+    // Local protection flag for `onBeforeInitialize`.
+    bool internal _isInitialized;
+
     // Protect functions that would otherwise be vulnerable to manipulation through transient liquidity.
     modifier onlyWhenVaultIsLocked() {
         _ensureVaultIsLocked();
@@ -310,9 +313,10 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         // There is no `pool` argument, but given that `onRegister` only allows this contract to register these hooks
         // for itself, `onlyVault` is sufficient. On the other hand, there is no reason to call this function
         // more than once, so we ensure that locally.
-        if (_vault.isPoolInitialized(address(this))) {
+        if (_isInitialized) {
             revert PoolAlreadyInitialized();
         }
+        _isInitialized = true;
 
         (uint256 virtualBalanceA, uint256 virtualBalanceB, uint256 priceRatio) = _helper
             .computeInitialVirtualBalancesAndRatio(balancesScaled18);

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -40,7 +40,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     // This means they have 0.00001% resolution (i.e., any non-zero bits < 1e11 will cause precision loss).
     // Minimum values help make the math well-behaved (i.e., the swap fee should overwhelm any rounding error).
     // Maximum values protect users by preventing permissioned actors from setting excessively high swap fees.
-    uint256 private constant _MIN_SWAP_FEE_PERCENTAGE = 0.001e16; // 0.001%
+    uint256 internal constant _MIN_SWAP_FEE_PERCENTAGE = 0.001e16; // 0.001%
     uint256 internal constant _MAX_SWAP_FEE_PERCENTAGE = 10e16; // 10%
 
     // The maximum pool centeredness allowed to consider the pool within the target range.
@@ -55,9 +55,10 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     // Price ratio updates must have both a minimum duration and a maximum daily rate. For instance, an update rate of
     // FP 2 means the ratio one day later must be at least half and at most double the rate at the start of the update.
     uint256 internal constant _MIN_PRICE_RATIO_UPDATE_DURATION = 1 days;
-    uint256 internal immutable _MAX_DAILY_PRICE_RATIO_UPDATE_RATE;
 
-    uint256 internal constant _MIN_PRICE_RATIO = 1.0001e18; // 0.01%
+    // Price ratio below 1 breaks pool math. Also, tight ratios close to FP(1) may also cause virtual balances
+    // to grow excessively, potentially causing numerical issues. In practice, such tight ratios should not be needed.
+    uint256 internal constant _MIN_PRICE_RATIO = 1.0001e18; // 0.01% above FP(1)
 
     // There is also a minimum delta, to keep the math well-behaved.
     uint256 internal constant _MIN_PRICE_RATIO_DELTA = 1e6;
@@ -67,8 +68,13 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     // solhint-disable-next-line immutable-vars-naming
     ReClammPoolHelper internal immutable _helper;
 
-    // Constant in the helper, cached here for convenience.
+    // Constant in the helper, cached here for convenience at construction time.
     uint256 private immutable _BALANCE_RATIO_AND_PRICE_TOLERANCE;
+
+    // Price ratio updates must have a maximum daily rate. For instance, an update rate of FP 2 means the ratio one
+    // day later must be at least half and at most double the rate at the start of the update.
+    // This value is calculated at construction time based on `_MAX_DAILY_PRICE_SHIFT_EXPONENT`.
+    uint256 internal immutable _MAX_DAILY_PRICE_RATIO_UPDATE_RATE;
 
     // These immutables are only used during initialization, to set the virtual balances and price ratio in a more
     // user-friendly manner.
@@ -552,6 +558,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         data.initialCenterednessMargin = _INITIAL_CENTEREDNESS_MARGIN;
 
         // Operating Limits
+        data.minPriceRatio = _MIN_PRICE_RATIO;
         data.maxCenterednessMargin = _MAX_CENTEREDNESS_MARGIN;
         data.maxDailyPriceShiftExponent = _MAX_DAILY_PRICE_SHIFT_EXPONENT;
         data.maxDailyPriceRatioUpdateRate = _MAX_DAILY_PRICE_RATIO_UPDATE_RATE;

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -112,9 +112,6 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     uint128 internal _lastVirtualBalanceA;
     uint128 internal _lastVirtualBalanceB;
 
-    // Local protection flag for `onBeforeInitialize`.
-    bool internal _isInitialized;
-
     // Protect functions that would otherwise be vulnerable to manipulation through transient liquidity.
     modifier onlyWhenVaultIsLocked() {
         _ensureVaultIsLocked();
@@ -313,10 +310,9 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         // There is no `pool` argument, but given that `onRegister` only allows this contract to register these hooks
         // for itself, `onlyVault` is sufficient. On the other hand, there is no reason to call this function
         // more than once, so we ensure that locally.
-        if (_isInitialized) {
+        if (_vault.isPoolInitialized(address(this))) {
             revert PoolAlreadyInitialized();
         }
-        _isInitialized = true;
 
         (uint256 virtualBalanceA, uint256 virtualBalanceB, uint256 priceRatio) = _helper
             .computeInitialVirtualBalancesAndRatio(balancesScaled18);

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -200,7 +200,7 @@ interface IReClammPool is IBasePool {
     error DailyPriceShiftExponentTooHigh();
 
     /// @notice The end price ratio is too low.
-    error EndPriceRatioBelowMin(uint endPriceRatio);
+    error EndPriceRatioBelowMin(uint256 endPriceRatio);
 
     /// @notice The difference between end time and start time is too short for the price ratio update.
     error PriceRatioUpdateDurationTooShort();

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -199,6 +199,9 @@ interface IReClammPool is IBasePool {
     /// @notice The daily price shift exponent is too high.
     error DailyPriceShiftExponentTooHigh();
 
+    /// @notice The end price ratio is too low.
+    error EndPriceRatioBelowMin(uint endPriceRatio);
+
     /// @notice The difference between end time and start time is too short for the price ratio update.
     error PriceRatioUpdateDurationTooShort();
 

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -224,6 +224,9 @@ interface IReClammPool is IBasePool {
      */
     error ReClammPoolBptRateUnsupported();
 
+    /// @dev `onBeforeInitialize` hook was called more than once.
+    error PoolAlreadyInitialized();
+
     /// @dev Function called before initializing the pool.
     error PoolNotInitialized();
 
@@ -238,6 +241,9 @@ interface IReClammPool is IBasePool {
 
     /// @notice The current price interval or spot price is outside the initialization price range.
     error WrongInitializationPrices();
+
+    // Hook was invoked with the wrong pool address.
+    error InvalidPoolArgument(address pool);
 
     /********************************************************
                        Pool State Getters

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -38,6 +38,7 @@ struct ReClammPoolParams {
  * @param initialTargetPrice The initial target price of token A in terms of token B (possibly applying rates)
  * @param initialDailyPriceShiftExponent The initial daily price shift exponent
  * @param initialCenterednessMargin The initial centeredness margin (threshold for initiating a range update)
+ * @param minPriceRatio The minimum price ratio (max price / min price) allowed for the pool, as an 18-decimal FP value
  * @param maxCenterednessMargin The maximum centeredness margin for the pool, as an 18-decimal FP percentage
  * @param maxDailyPriceShiftExponent The maximum exponent for the pool's price shift, as an 18-decimal FP percentage
  * @param maxDailyPriceRatioUpdateRate The maximum percentage the price range can expand/contract per day
@@ -60,6 +61,7 @@ struct ReClammPoolImmutableData {
     uint256 initialDailyPriceShiftExponent;
     uint256 initialCenterednessMargin;
     // Operating Limits
+    uint256 minPriceRatio;
     uint256 maxCenterednessMargin;
     uint256 maxDailyPriceShiftExponent;
     uint256 maxDailyPriceRatioUpdateRate;

--- a/foundry.toml
+++ b/foundry.toml
@@ -23,7 +23,7 @@ remappings = [
 ]
 optimizer = true
 optimizer_runs = 999
-solc_version = '0.8.26'
+solc_version = '0.8.27'
 auto_detect_solc = false
 evm_version = 'cancun'
 ignored_error_codes = [2394, 5574, 3860] # Transient storage, code size

--- a/test/foundry/ReClammMath.t.sol
+++ b/test/foundry/ReClammMath.t.sol
@@ -349,7 +349,8 @@ contract ReClammMathTest is BaseReClammTest {
 
         uint256 actualPriceRatio = actualRootPriceRatio.mulDown(actualRootPriceRatio);
 
-        assertApproxEqAbs(expectedPriceRatio, actualPriceRatio, _MAX_PRICE_ERROR_ABS, "Price Ratio should be correct");
+        // 0.001% error tolerance.
+        assertApproxEqRel(expectedPriceRatio, actualPriceRatio, 0.001e16, "Price Ratio should be correct");
     }
 
     function testComputeFourthRootPriceRatioWhenCurrentTimeIsEndTime() public pure {

--- a/test/foundry/ReClammMath.t.sol
+++ b/test/foundry/ReClammMath.t.sol
@@ -349,8 +349,18 @@ contract ReClammMathTest is BaseReClammTest {
 
         uint256 actualPriceRatio = actualRootPriceRatio.mulDown(actualRootPriceRatio);
 
-        // 0.001% error tolerance.
-        assertApproxEqRel(expectedPriceRatio, actualPriceRatio, 0.001e16, "Price Ratio should be correct");
+        // 0.01% error tolerance.
+        assertApproxEqRel(expectedPriceRatio, actualPriceRatio, 0.01e16, "Price Ratio should be correct");
+
+        // For smaller price ratios, also check absolute error tolerance.
+        if (expectedFourthRootPriceRatio < 5e18) {
+            assertApproxEqAbs(
+                expectedPriceRatio,
+                actualPriceRatio,
+                _MAX_PRICE_ERROR_ABS,
+                "Price Ratio should be correct"
+            );
+        }
     }
 
     function testComputeFourthRootPriceRatioWhenCurrentTimeIsEndTime() public pure {

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -67,7 +67,22 @@ contract ReClammPoolTest is BaseReClammTest {
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, address(this)));
         ReClammPool(pool).onBeforeAddLiquidity(
             address(this),
+            pool,
+            AddLiquidityKind.PROPORTIONAL,
+            new uint256[](2),
+            0,
+            new uint256[](2),
+            bytes("")
+        );
+    }
+
+    function testOnBeforeAddLiquidityPoolArgument() public {
+        address wrongPool = address(0x123);
+        vm.prank(address(vault));
+        vm.expectRevert(abi.encodeWithSelector(IReClammPool.InvalidPoolArgument.selector, wrongPool));
+        ReClammPool(pool).onBeforeAddLiquidity(
             address(this),
+            wrongPool,
             AddLiquidityKind.PROPORTIONAL,
             new uint256[](2),
             0,
@@ -80,7 +95,22 @@ contract ReClammPoolTest is BaseReClammTest {
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, address(this)));
         ReClammPool(pool).onBeforeRemoveLiquidity(
             address(this),
+            pool,
+            RemoveLiquidityKind.PROPORTIONAL,
+            1,
+            new uint256[](2),
+            new uint256[](2),
+            bytes("")
+        );
+    }
+
+    function testOnBeforeRemoveLiquidityPoolArgument() public {
+        address wrongPool = address(0x123);
+        vm.prank(address(vault));
+        vm.expectRevert(abi.encodeWithSelector(IReClammPool.InvalidPoolArgument.selector, wrongPool));
+        ReClammPool(pool).onBeforeRemoveLiquidity(
             address(this),
+            wrongPool,
             RemoveLiquidityKind.PROPORTIONAL,
             1,
             new uint256[](2),
@@ -1239,6 +1269,11 @@ contract ReClammPoolTest is BaseReClammTest {
 
         vm.prank(alice);
         router.initialize(newPool, tokens, _initialBalances, 0, false, bytes(""));
+
+        // Can't call `onBeforeInitialize` twice.
+        vm.prank(address(vault));
+        vm.expectRevert(IReClammPool.PoolAlreadyInitialized.selector);
+        ReClammPool(newPool).onBeforeInitialize(_initialBalances, "");
     }
 
     function testSetDailyPriceShiftExponentTooHigh() public {

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -52,6 +52,51 @@ contract ReClammPoolTest is BaseReClammTest {
 
     ReClammMathMock mathMock = new ReClammMathMock();
 
+    function testOnRegisterPoolArgument() public view {
+        address wrongPool = address(0x123);
+        TokenConfig[] memory tokenConfig = new TokenConfig[](2);
+        LiquidityManagement memory liquidityManagement;
+        liquidityManagement.disableUnbalancedLiquidity = true;
+        liquidityManagement.enableDonation = false;
+        bool result = ReClammPool(pool).onRegister(poolFactory, wrongPool, tokenConfig, liquidityManagement);
+        assertFalse(result, "onRegister should return false for wrong pool argument");
+    }
+
+    function testOnRegisterTokenConfig() public view {
+        TokenConfig[] memory tokenConfig = new TokenConfig[](3);
+        LiquidityManagement memory liquidityManagement;
+        liquidityManagement.disableUnbalancedLiquidity = true;
+        liquidityManagement.enableDonation = false;
+        bool result = ReClammPool(pool).onRegister(poolFactory, pool, tokenConfig, liquidityManagement);
+        assertFalse(result, "onRegister should return false for wrong token config length");
+    }
+
+    function testOnRegisterLiquidityManagement() public view {
+        TokenConfig[] memory tokenConfig = new TokenConfig[](2);
+        LiquidityManagement memory liquidityManagement;
+        liquidityManagement.disableUnbalancedLiquidity = false;
+        liquidityManagement.enableDonation = false;
+        bool result = ReClammPool(pool).onRegister(poolFactory, pool, tokenConfig, liquidityManagement);
+        assertFalse(
+            result,
+            "onRegister should return false for wrong liquidity management (disableUnbalancedLiquidity)"
+        );
+
+        liquidityManagement.disableUnbalancedLiquidity = true;
+        liquidityManagement.enableDonation = true;
+        result = ReClammPool(pool).onRegister(poolFactory, pool, tokenConfig, liquidityManagement);
+        assertFalse(result, "onRegister should return false for wrong liquidity management (enableDonation)");
+    }
+
+    function testOnRegisterCorrectArguments() public view {
+        TokenConfig[] memory tokenConfig = new TokenConfig[](2);
+        LiquidityManagement memory liquidityManagement;
+        liquidityManagement.disableUnbalancedLiquidity = true;
+        liquidityManagement.enableDonation = false;
+        bool result = ReClammPool(pool).onRegister(poolFactory, pool, tokenConfig, liquidityManagement);
+        assertTrue(result, "onRegister should return true for correct arguments");
+    }
+
     function testOnSwapOnlyVault() public {
         PoolSwapParams memory request;
         vm.expectRevert(abi.encodeWithSelector(IVaultErrors.SenderIsNotVault.selector, address(this)));

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -35,6 +35,7 @@ contract ReClammPoolTest is BaseReClammTest {
     using ArrayHelpers for *;
     using SafeCast for *;
 
+    uint256 private constant _ABSOLUTE_MIN_PRICE_RATIO = 1.0001e18; // 0.01%
     uint256 private constant _NEW_CENTEREDNESS_MARGIN = 30e16;
     uint256 private constant _INITIAL_AMOUNT = 1000e18;
 
@@ -421,6 +422,16 @@ contract ReClammPoolTest is BaseReClammTest {
         // boundary. And the error is only raised in the external function, so we can't use the mock here. Best we can
         // do is set a large update that would be too fast, and show that the error is triggered.
         vm.expectRevert(IReClammPool.PriceRatioUpdateTooFast.selector);
+        vm.prank(admin);
+        ReClammPool(pool).startPriceRatioUpdate(newPriceRatio, priceRatioUpdateStartTime, priceRatioUpdateEndTime);
+    }
+
+    function testSetPriceRatioTooLow() public {
+        uint256 newPriceRatio = _ABSOLUTE_MIN_PRICE_RATIO - 1;
+        uint256 priceRatioUpdateStartTime = block.timestamp;
+        uint256 priceRatioUpdateEndTime = block.timestamp + 1 days;
+
+        vm.expectRevert(abi.encodeWithSelector(IReClammPool.EndPriceRatioBelowMin.selector, newPriceRatio));
         vm.prank(admin);
         ReClammPool(pool).startPriceRatioUpdate(newPriceRatio, priceRatioUpdateStartTime, priceRatioUpdateEndTime);
     }

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -348,6 +348,7 @@ contract ReClammPoolTest is BaseReClammTest {
         assertEq(data.initialCenterednessMargin, _DEFAULT_CENTEREDNESS_MARGIN, "Invalid initial centeredness margin");
 
         // Check operating limit parameters.
+        assertEq(data.minPriceRatio, _ABSOLUTE_MIN_PRICE_RATIO, "Invalid min price ratio");
         assertEq(data.maxCenterednessMargin, _MAX_CENTEREDNESS_MARGIN, "Invalid max centeredness margin");
 
         // Ensure that the max centeredness margin parameter fits in uint64.


### PR DESCRIPTION
# Description

Add protections for non-view hooks (`onBefore...`) so that they cannot be called by attackers using fake pools pointing to legit pools as hooks.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A