### PR TITLE
[2.1] Fix init test

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -440,9 +440,10 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         ) = _getRealAndVirtualBalances();
 
         // Undo rate effects to return the spot price in terms of actual token amounts.
+        // This computation doesn't favor the Vault in any way as it is an external getter; we round down the result.
         return
             ((balancesScaled18[b] + currentVirtualBalanceB) * tokenRates[a]) /
-            (balancesScaled18[a] + currentVirtualBalanceA).mulDown(tokenRates[b]);
+            (balancesScaled18[a] + currentVirtualBalanceA).mulUp(tokenRates[b]);
     }
 
     function _getRealAndVirtualBalances()

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -431,6 +431,7 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
 
     /// @inheritdoc IReClammPool
     function computeCurrentSpotPrice() external view returns (uint256) {
+        (, uint256[] memory tokenRates) = _vault.getPoolTokenRates(address(this));
         (
             uint256[] memory balancesScaled18,
             uint256 currentVirtualBalanceA,
@@ -438,7 +439,10 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
 
         ) = _getRealAndVirtualBalances();
 
-        return (balancesScaled18[b] + currentVirtualBalanceB).divDown(balancesScaled18[a] + currentVirtualBalanceA);
+        // Undo rate effects to return the spot price in terms of actual token amounts.
+        return
+            ((balancesScaled18[b] + currentVirtualBalanceB) * tokenRates[a]) /
+            (balancesScaled18[a] + currentVirtualBalanceA).mulDown(tokenRates[b]);
     }
 
     function _getRealAndVirtualBalances()

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -302,12 +302,25 @@ interface IReClammPool is IBasePool {
         returns (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, bool changed);
 
     /**
-     * @notice Computes the current target price. This is the ratio of the total (i.e., real + virtual) balances (B/A).
-     * @dev Given the nature of the internal pool maths (particularly when virtual balances are shifting), it is not
-     * recommended to use this pool as a price oracle.
-     * @return currentTargetPrice Target price at the current pool state (real and virtual balances)
+     * @notice Computes the current spot price of token B in terms of token A: i.e., how many token A units are
+     * required to purchase one token B, or equivalently, how many token A units you receive per token B sold.
+     * @dev The price is expressed as token/token (e.g., wstETH/USDC), not underlying/underlying (e.g. ETH/USDC).
+     * This matches what a swapper experiences: if this function returns 3000, then swapping 3000 USDC yields
+     * approximately 1 wstETH. Internally, the spot price is derived from live (rate-scaled) balances plus virtual
+     * balances, then adjusted by the ratio of token rates (rateA / rateB) to convert from the underlying/underlying
+     * price that the AMM math operates on to the token/token price that callers expect. For pools with no rate
+     * providers (or rate = 1), the two are identical.
+     *
+     * Note that `initialTargetPrice` may have been specified in either token or underlying terms depending on
+     * `tokenAPriceIncludesRate` / `tokenBPriceIncludesRate`, so it cannot in general be directly compared to this
+     * return value.
+     *
+     * Given the nature of the internal pool math (particularly when virtual balances are shifting), it is not
+     * recommended to use this pool as a price oracle.
+     *
+     * @return currentSpotPrice Spot price at the current pool state (real and virtual balances), in token/token terms
      */
-    function computeCurrentSpotPrice() external view returns (uint256 currentTargetPrice);
+    function computeCurrentSpotPrice() external view returns (uint256 currentSpotPrice);
 
     /**
      * @notice Getter for the timestamp of the last user interaction.

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -303,22 +303,22 @@ interface IReClammPool is IBasePool {
 
     /**
      * @notice Computes the current spot price of token B in terms of token A: i.e., how many token A units are
-     * required to purchase one token B, or equivalently, how many token A units you receive per token B sold.
-     * @dev The price is expressed as token/token (e.g., wstETH/USDC), not underlying/underlying (e.g. ETH/USDC).
-     * This matches what a swapper experiences: if this function returns 3000, then swapping 3000 USDC yields
-     * approximately 1 wstETH. Internally, the spot price is derived from live (rate-scaled) balances plus virtual
-     * balances, then adjusted by the ratio of token rates (rateA / rateB) to convert from the underlying/underlying
-     * price that the AMM math operates on to the token/token price that callers expect. For pools with no rate
-     * providers (or rate = 1), the two are identical.
-     *
-     * Note that `initialTargetPrice` may have been specified in either token or underlying terms depending on
-     * `tokenAPriceIncludesRate` / `tokenBPriceIncludesRate`, so it cannot in general be directly compared to this
-     * return value.
-     *
-     * Given the nature of the internal pool math (particularly when virtual balances are shifting), it is not
-     * recommended to use this pool as a price oracle.
-     *
-     * @return currentSpotPrice Spot price at the current pool state (real and virtual balances), in token/token terms
+     * required to purchase one token B, or equivalently, how many token A units you receive per token B sold.
+     * @dev The price is expressed as token/token (e.g., wstETH/USDC), not underlying/underlying (e.g. ETH/USDC).
+     * This matches what a swapper experiences: if this function returns 3000, then swapping 3000 USDC yields
+     * approximately 1 wstETH. Internally, the spot price is derived from live (rate-scaled) balances plus virtual
+     * balances, then adjusted by the ratio of token rates (rateA / rateB) to convert from the underlying/underlying
+     * price that the AMM math operates on to the token/token price that callers expect. For pools with no rate
+     * providers (or rate = 1), the two are identical.
+     *
+     * Note that `initialTargetPrice` may have been specified in either token or underlying terms depending on
+     * `tokenAPriceIncludesRate` / `tokenBPriceIncludesRate`, so it cannot in general be directly compared to this
+     * return value.
+     *
+     * Given the nature of the internal pool math (particularly when virtual balances are shifting), it is not
+     * recommended to use this pool as a price oracle.
+     *
+     * @return currentSpotPrice Spot price at the current pool state (real and virtual balances), in token/token terms
      */
     function computeCurrentSpotPrice() external view returns (uint256 currentSpotPrice);
 

--- a/test/foundry/ReclammPoolInit.t.sol
+++ b/test/foundry/ReclammPoolInit.t.sol
@@ -41,6 +41,8 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
     uint256 private constant _INITIAL_AMOUNT = 1000e18;
 
+    address eurc;
+
     function setUp() public override {
         super.setUp();
 
@@ -54,6 +56,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         usdc6Decimals.approve(address(permit2), type(uint256).max);
         permit2.approve(address(usdc6Decimals), address(router), type(uint160).max, type(uint48).max);
         vm.stopPrank();
+        eurc = address(dai); // let's just say this is EURC
     }
 
     function testComputeInitialBalancesInvalidToken() public {
@@ -137,6 +140,10 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _tokenAPriceIncludesRate = tokenAWithRate;
         _tokenBPriceIncludesRate = tokenBWithRate;
         initialAmount = initialAmount / 10 ** (18 - IERC20Metadata(address(sortedTokens[b])).decimals());
+        // When the flag is set, we'll have a deviation with respect to the initial target price.
+        uint256 expectedSpotPrice = _initialTargetPrice
+            .mulDown(_tokenAPriceIncludesRate ? rateA : FixedPoint.ONE)
+            .divDown(_tokenBPriceIncludesRate ? rateB : FixedPoint.ONE);
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -185,21 +192,23 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenB, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
         vm.revertToState(snapshotId);
 
         _initPool(newPool, initialBalancesRawGivenA, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
     }
 
     function testComputeInitialBalancesUsdcEth() public {
         require(address(usdc6Decimals) > address(weth), "Incorrect token order");
         // Spot price is 2.5k ETH/USDC. There are no rate providers here so flags don't really matter.
+        uint256 expectedSpotPrice = _initialTargetPrice;
         IERC20[] memory sortedTokens = [address(weth), address(usdc6Decimals)].toMemoryArray().asIERC20();
         (uint256 wethIndex, uint256 usdcIndex) = (a, b);
 
         _tokenAPriceIncludesRate = false;
         _tokenBPriceIncludesRate = false;
+
         uint256 initialAmount = 100e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
@@ -243,32 +252,28 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWeth, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenWeth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWeth, 0.01e16, "Spot prices are not equal");
-        assertApproxEqRel(
-            spotPriceGivenUsdc,
-            _initialTargetPrice,
-            0.01e16,
-            "Spot prices differ from initial target price"
-        );
     }
 
     function testComputeInitialBalancesUsdcEthFlagsTrue() public {
         require(address(usdc6Decimals) > address(weth), "Incorrect token order");
         // Spot price is 2.5k ETH/USDC. There are no rate providers here so flags don't really matter.
+        uint256 expectedSpotPrice = _initialTargetPrice;
         IERC20[] memory sortedTokens = [address(weth), address(usdc6Decimals)].toMemoryArray().asIERC20();
         (uint256 wethIndex, uint256 usdcIndex) = (a, b);
 
         _tokenAPriceIncludesRate = true;
         _tokenBPriceIncludesRate = true;
+
         uint256 initialAmount = 100e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
@@ -312,31 +317,25 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshot();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertTo(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWeth, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenWeth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWeth, 0.01e16, "Spot prices are not equal");
-        assertApproxEqRel(
-            spotPriceGivenUsdc,
-            _initialTargetPrice,
-            0.01e16,
-            "Spot prices differ from initial target price"
-        );
     }
 
     function testComputeInitialBalancesUsdcWstEth() public {
         require(address(usdc6Decimals) > address(weth), "Incorrect token order");
         uint256 wstEthRate = 1.2e18;
-        uint256 initialUnderlyingPrice = _initialTargetPrice;
 
         // Spot price for ETH/USDC is 2.5k, so spot price is 3k for wstETH/USDC, i.e. 2.5k * rate.
         _initialTargetPrice = _initialTargetPrice.mulDown(wstEthRate);
+        uint256 expectedSpotPrice = _initialTargetPrice;
 
         IERC20[] memory sortedTokens = [address(weth), address(usdc6Decimals)].toMemoryArray().asIERC20();
         (uint256 wethIndex, uint256 usdcIndex) = (a, b);
@@ -387,29 +386,24 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWstEth, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
+
         uint256 spotPriceGivenWstEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWstEth, 0.1e16, "Spot prices are not equal");
-        // The spot price is always computed in terms of the tokens without the rates, so this would be ETH/USDC.
-        assertApproxEqRel(
-            spotPriceGivenUsdc,
-            initialUnderlyingPrice,
-            0.01e16,
-            "Spot prices differ from initial target price"
-        );
     }
 
     function testComputeInitialBalancesUsdcWaEth() public {
         require(address(usdc6Decimals) > address(weth), "Incorrect token order");
         uint256 waWethRate = 1.2e18;
 
-        // Spot price is 2.5k for ETH/USDC --> spot price for waETH/USDC is 2.5k * 1.2
+        // Spot price is 2.5k for ETH/USDC --> spot price for waETH/USDC is 2.5k * 1.2 = 3000
+        uint256 expectedSpotPrice = _initialTargetPrice.mulDown(waWethRate);
         IERC20[] memory sortedTokens = [address(weth), address(usdc6Decimals)].toMemoryArray().asIERC20();
         (uint256 wethIndex, uint256 usdcIndex) = (a, b);
 
@@ -458,22 +452,15 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWaEth, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWaEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWaEth, 0.1e16, "Spot prices are not equal");
-        // The actual spot price after initialization corresponds to WETH/USDC, so it matches the initial one.
-        assertApproxEqRel(
-            spotPriceGivenUsdc,
-            _initialTargetPrice,
-            0.01e16,
-            "Spot prices differ from initial target price"
-        );
     }
 
     function testComputeInitialBalancesWaUsdcWaEth() public {
@@ -481,7 +468,8 @@ contract ReClammPoolInitTest is BaseReClammTest {
         uint256 waWethRate = 1.2e18;
         uint256 waUsdcRate = 1.5e18;
 
-        // Spot price is 2.5k for ETH/USDC --> spot price of waWETH / waUSDC does not matter here.
+        // Spot price is 2.5k for ETH/USDC --> spot price of waWETH / waUSDC is 2.5k * 1.2 / 1.5 = 2000.
+        uint256 expectedSpotPrice = _initialTargetPrice.mulDown(waWethRate).divDown(waUsdcRate);
         IERC20[] memory sortedTokens = [address(weth), address(usdc6Decimals)].toMemoryArray().asIERC20();
         (uint256 wethIndex, uint256 usdcIndex) = (a, b);
 
@@ -530,43 +518,34 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenWaUsdc, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenWaUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWaEth, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWaEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenWaUsdc, spotPriceGivenWaEth, 0.1e16, "Spot prices are not equal");
-        // The actual spot price after initialization corresponds to WETH/USDC, so it matches the one specified
-        // at creation time.
-        assertApproxEqRel(
-            spotPriceGivenWaUsdc,
-            _initialTargetPrice,
-            0.01e16,
-            "Spot prices differ from initial target price"
-        );
     }
 
     function testComputeInitialBalancesWaUsdcWaEurc() public {
         uint256 eurUsdRate = 1.17e18;
-
-        address eurc = address(dai); // let's just say this is EURC
         require(address(usdc6Decimals) > address(eurc), "Incorrect token order");
         uint256 waEurcRate = 1.01e18;
         uint256 waUsdcRate = 1.1e18;
 
-        // Spot price is 1.17 for ETH/USDC --> spot price of waWETH / waUSDC does not matter here.
+        // Spot price is 1.17 for EUR/USDC --> spot price of waEUR / waUSDC is 1.17 * 1.01 / 1.1.
         _initialMaxPrice = eurUsdRate.mulDown(1.02e18);
         _initialTargetPrice = eurUsdRate;
         _initialMinPrice = eurUsdRate.mulDown(0.98e18);
+        uint256 expectedSpotPrice = _initialTargetPrice.mulDown(waEurcRate).divDown(waUsdcRate);
 
         IERC20[] memory sortedTokens = [address(eurc), address(usdc6Decimals)].toMemoryArray().asIERC20();
         (uint256 eurcIndex, uint256 usdcIndex) = (a, b);
 
-        // We'll specify the spot price in terms of ETH/USDC, both flags to true.
-        // waWeth has a rate with respect to ETH, and waUSDC has a rate with respect to USDC.
+        // We'll specify the spot price in terms of EUR/USDC, both flags to true.
+        // waEURC has a rate with respect to EURC, and waUSDC has a rate with respect to USDC.
         _tokenAPriceIncludesRate = true;
         _tokenBPriceIncludesRate = true;
         _rateProviderA.mockRate(waEurcRate);
@@ -610,18 +589,15 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenWaUsdc, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenWaUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWaEurc, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWaEurc = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenWaUsdc, spotPriceGivenWaEurc, 0.1e16, "Spot prices are not equal");
-        // The actual spot price after initialization corresponds to WETH/USDC, so it matches the one specified
-        // at creation time.
-        assertApproxEqRel(spotPriceGivenWaUsdc, eurUsdRate, 0.01e16, "Spot prices differ from initial target price");
     }
 
     function testComputeInitialBalancesWstEthsDai() public {
@@ -630,9 +606,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
         uint256 waUsdcRate = 1.5e18;
 
         // WETH/DAI is 2.5k
-        uint256 initialUnderlyingPrice = _initialTargetPrice;
-        _initialTargetPrice = _initialTargetPrice.mulDown(waWethRate).divDown(waUsdcRate);
         // Spot price is 2.5k for ETH/USDC --> spot price for wstETH/sDAI is 2.5k * 1.2 / 1.5 = 2000
+        _initialTargetPrice = _initialTargetPrice.mulDown(waWethRate).divDown(waUsdcRate);
+        uint256 expectedSpotPrice = _initialTargetPrice;
         IERC20[] memory sortedTokens = [address(weth), address(usdc6Decimals)].toMemoryArray().asIERC20();
         (uint256 wethIndex, uint256 usdcIndex) = (a, b);
 
@@ -680,30 +656,26 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenSDai, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
 
         uint256 spotPriceGivenSDai = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWstEth, 0);
-        _validatePostInitConditions(newPool);
+        _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWstEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenSDai, spotPriceGivenWstEth, 0.1e16, "Spot prices are not equal");
-        // The spot price is always underlying / underlying, so it has to be 2.5k
-        assertApproxEqRel(
-            spotPriceGivenSDai,
-            initialUnderlyingPrice,
-            0.01e16,
-            "Spot prices differ from initial target price"
-        );
     }
 
-    function _validatePostInitConditions(address pool) private view {
+    function _validatePostInitConditions(address pool, uint256 expectedSpotPrice) private view {
         assertTrue(vault.isPoolInitialized(pool), "Pool is not initialized");
 
         // Validate price ratio and target.
         (uint256 minPrice, uint256 maxPrice) = ReClammPool(pool).computeCurrentPriceRange();
         ReClammPoolImmutableData memory data = ReClammPool(pool).getReClammPoolImmutableData();
+        assertEq(data.initialMinPrice, _initialMinPrice, "Initial min price doesn't match specified one");
+        assertEq(data.initialMaxPrice, _initialMaxPrice, "Initial max price doesn't match specified one");
+        assertEq(data.initialTargetPrice, _initialTargetPrice, "Initial target price doesn't match specified one");
 
         assertApproxEqRel(
             maxPrice.divDown(minPrice),
@@ -712,10 +684,10 @@ contract ReClammPoolInitTest is BaseReClammTest {
             "Wrong price ratio after initialization with rate"
         );
 
-        uint256 targetPrice = ReClammPool(pool).computeCurrentSpotPrice();
+        uint256 spotPrice = ReClammPool(pool).computeCurrentSpotPrice();
         assertApproxEqRel(
-            targetPrice,
-            data.initialTargetPrice,
+            spotPrice,
+            expectedSpotPrice,
             _INITIAL_PARAMS_ERROR,
             "Wrong target price after initialization with rate"
         );

--- a/test/foundry/ReclammPoolInit.t.sol
+++ b/test/foundry/ReclammPoolInit.t.sol
@@ -131,7 +131,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         bool tokenAWithRate,
         bool tokenBWithRate
     ) public {
-        initialAmount = bound(initialAmount, 1e18, _INITIAL_AMOUNT);
+        initialAmount = bound(initialAmount, _INITIAL_AMOUNT * 1e6, _INITIAL_AMOUNT * 1e9);
         rateA = bound(rateA, 1e18, 100e18);
         rateB = bound(rateB, 1e18, 100e18);
         IERC20[] memory sortedTokens = InputHelpers.sortTokens(
@@ -197,6 +197,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         _initPool(newPool, initialBalancesRawGivenA, 0);
         _validatePostInitConditions(newPool, expectedSpotPrice);
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function testComputeInitialBalancesUsdcEth() public {
@@ -209,7 +212,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _tokenAPriceIncludesRate = false;
         _tokenBPriceIncludesRate = false;
 
-        uint256 initialAmount = 100e6;
+        uint256 initialAmount = 10_000_000e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -262,6 +265,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 spotPriceGivenWeth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWeth, 0.01e16, "Spot prices are not equal");
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function testComputeInitialBalancesUsdcEthFlagsTrue() public {
@@ -274,7 +280,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _tokenAPriceIncludesRate = true;
         _tokenBPriceIncludesRate = true;
 
-        uint256 initialAmount = 100e6;
+        uint256 initialAmount = 10_000_000e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -327,6 +333,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 spotPriceGivenWeth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWeth, 0.01e16, "Spot prices are not equal");
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function testComputeInitialBalancesUsdcWstEth() public {
@@ -347,7 +356,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _rateProviderA.mockRate(wstEthRate);
         _rateProviderB.mockRate(FixedPoint.ONE);
 
-        uint256 initialAmount = 100e6;
+        uint256 initialAmount = 10_000_000e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -396,6 +405,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 spotPriceGivenWstEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWstEth, 0.1e16, "Spot prices are not equal");
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function testComputeInitialBalancesUsdcWaEth() public {
@@ -413,7 +425,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _tokenBPriceIncludesRate = false;
         _rateProviderA.mockRate(waWethRate);
         _rateProviderB.mockRate(FixedPoint.ONE);
-        uint256 initialAmount = 100e6;
+        uint256 initialAmount = 10_000_000e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -461,6 +473,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWaEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWaEth, 0.1e16, "Spot prices are not equal");
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function testComputeInitialBalancesWaUsdcWaEth() public {
@@ -479,7 +494,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _tokenBPriceIncludesRate = true;
         _rateProviderA.mockRate(waWethRate);
         _rateProviderB.mockRate(waUsdcRate);
-        uint256 initialAmount = 100e6;
+        uint256 initialAmount = 10_000_000e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -527,6 +542,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWaEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenWaUsdc, spotPriceGivenWaEth, 0.1e16, "Spot prices are not equal");
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function testComputeInitialBalancesWaUsdcWaEurc() public {
@@ -550,7 +568,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _tokenBPriceIncludesRate = true;
         _rateProviderA.mockRate(waEurcRate);
         _rateProviderB.mockRate(waUsdcRate);
-        uint256 initialAmount = 100e6;
+        uint256 initialAmount = 10_000_000e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -598,6 +616,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWaEurc = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenWaUsdc, spotPriceGivenWaEurc, 0.1e16, "Spot prices are not equal");
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function testComputeInitialBalancesWstEthsDai() public {
@@ -617,7 +638,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _tokenBPriceIncludesRate = false;
         _rateProviderA.mockRate(waWethRate);
         _rateProviderB.mockRate(waUsdcRate);
-        uint256 initialAmount = 100e6;
+        uint256 initialAmount = 10_000_000e6;
 
         (address newPool, ) = _createPool(sortedTokens.asAddress(), "BeforeInitTest");
 
@@ -665,6 +686,9 @@ contract ReClammPoolInitTest is BaseReClammTest {
         _validatePostInitConditions(newPool, expectedSpotPrice);
         uint256 spotPriceGivenWstEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenSDai, spotPriceGivenWstEth, 0.1e16, "Spot prices are not equal");
+        vm.stopPrank();
+
+        _validateActualSpotPrice(newPool);
     }
 
     function _validatePostInitConditions(address pool, uint256 expectedSpotPrice) private view {
@@ -691,5 +715,42 @@ contract ReClammPoolInitTest is BaseReClammTest {
             _INITIAL_PARAMS_ERROR,
             "Wrong target price after initialization with rate"
         );
+    }
+
+    function _validateActualSpotPrice(address pool) private {
+        uint256 spotPrice = ReClammPool(pool).computeCurrentSpotPrice();
+        IERC20[] memory tokens = vault.getPoolTokens(pool);
+
+        // Spot price is defined as the amount of input tokens required to get a single unit of output token
+        // when dismissing price impact.
+        // E.g. for an ETH/USDC pool where ETH is token A and USDC is token B, the spot price is how much USDC
+        // is needed per unit of ETH.
+        // Therefore, token B is token in.
+        IERC20 tokenIn = tokens[b];
+        IERC20 tokenOut = tokens[a];
+
+        // Use a small amount to minimize price impact (1/100th of a token in raw amounts)
+        uint256 smallAmountIn = FixedPoint.ONE / 10 ** (18 - IERC20Metadata(address(tokenIn)).decimals()) / 100;
+        uint256 smallAmountOut = FixedPoint.ONE / 10 ** (18 - IERC20Metadata(address(tokenOut)).decimals()) / 100;
+
+        uint256 snapshotId = vm.snapshotState();
+
+        _prankStaticCall();
+        uint256 actualAmountOut = router.querySwapSingleTokenExactIn(
+            pool,
+            tokenIn,
+            tokenOut,
+            smallAmountIn.mulDown(spotPrice),
+            address(this),
+            ""
+        );
+        assertApproxEqRel(
+            smallAmountOut,
+            actualAmountOut,
+            0.01e16,
+            "A small test swap does not verify the expected spot price after initialization"
+        );
+
+        vm.revertToState(snapshotId);
     }
 }

--- a/test/foundry/ReclammPoolInit.t.sol
+++ b/test/foundry/ReclammPoolInit.t.sol
@@ -37,7 +37,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
     using ArrayHelpers for *;
     using CastingHelpers for *;
 
-    uint256 private constant _INITIAL_PARAMS_ERROR = 1e6;
+    uint256 private constant _INITIAL_PARAMS_ERROR = 0.0001e16; // 0.0001% error
 
     uint256 private constant _INITIAL_AMOUNT = 1000e18;
 
@@ -185,11 +185,11 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenB, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
         vm.revertToState(snapshotId);
 
         _initPool(newPool, initialBalancesRawGivenA, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
     }
 
     function testComputeInitialBalancesUsdcEth() public {
@@ -243,13 +243,13 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWeth, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenWeth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWeth, 0.01e16, "Spot prices are not equal");
@@ -312,13 +312,13 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshot();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertTo(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWeth, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenWeth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWeth, 0.01e16, "Spot prices are not equal");
@@ -387,13 +387,13 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWstEth, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
         uint256 spotPriceGivenWstEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWstEth, 0.1e16, "Spot prices are not equal");
         // The spot price is always computed in terms of the tokens without the rates, so this would be ETH/USDC.
@@ -458,13 +458,13 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenUsdc, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWaEth, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
         uint256 spotPriceGivenWaEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenUsdc, spotPriceGivenWaEth, 0.1e16, "Spot prices are not equal");
         // The actual spot price after initialization corresponds to WETH/USDC, so it matches the initial one.
@@ -530,13 +530,13 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenWaUsdc, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenWaUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWaEth, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
         uint256 spotPriceGivenWaEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenWaUsdc, spotPriceGivenWaEth, 0.1e16, "Spot prices are not equal");
         // The actual spot price after initialization corresponds to WETH/USDC, so it matches the one specified
@@ -610,13 +610,13 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenWaUsdc, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenWaUsdc = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWaEurc, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
         uint256 spotPriceGivenWaEurc = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenWaUsdc, spotPriceGivenWaEurc, 0.1e16, "Spot prices are not equal");
         // The actual spot price after initialization corresponds to WETH/USDC, so it matches the one specified
@@ -680,13 +680,13 @@ contract ReClammPoolInitTest is BaseReClammTest {
 
         uint256 snapshotId = vm.snapshotState();
         _initPool(newPool, initialBalancesRawGivenSDai, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
 
         uint256 spotPriceGivenSDai = ReClammPool(newPool).computeCurrentSpotPrice();
 
         vm.revertToState(snapshotId);
         _initPool(newPool, initialBalancesRawGivenWstEth, 0);
-        _validatePostInitConditions();
+        _validatePostInitConditions(newPool);
         uint256 spotPriceGivenWstEth = ReClammPool(newPool).computeCurrentSpotPrice();
         assertApproxEqRel(spotPriceGivenSDai, spotPriceGivenWstEth, 0.1e16, "Spot prices are not equal");
         // The spot price is always underlying / underlying, so it has to be 2.5k
@@ -698,7 +698,7 @@ contract ReClammPoolInitTest is BaseReClammTest {
         );
     }
 
-    function _validatePostInitConditions() private view {
+    function _validatePostInitConditions(address pool) private view {
         assertTrue(vault.isPoolInitialized(pool), "Pool is not initialized");
 
         // Validate price ratio and target.


### PR DESCRIPTION
# Description

The spot price computation is not correctly defined.
It should represent the amount of tokens in required per unit token out, given small amounts with respect to the pool totals (i.e. dismissing price impact).

This PR corrects the getter, and adjusts the tests.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

N/A