### PR TITLE
Simplify computePriceRatio comment

### DIFF
--- a/contracts/lib/ReClammMath.sol
+++ b/contracts/lib/ReClammMath.sol
@@ -677,10 +677,7 @@ library ReClammMath {
     ) internal pure returns (uint256 priceRatio) {
         (uint256 minPrice, uint256 maxPrice) = computePriceRange(balancesScaled18, virtualBalanceA, virtualBalanceB);
 
-        // This value is used as the denominator in the rate check (endPriceRatio / startPriceRatio). Rounding down
-        // makes startPriceRatio smaller, which makes the computed rate appear larger, which makes the rate check
-        // harder to pass. This is the conservative direction, consistent with the initialization code (see
-        // computeTheoreticalPriceRatioAndBalances), which also uses divDown.
+        // Round down for consistency with initialization (computeTheoreticalPriceRatioAndBalances).
         return maxPrice.divDown(minPrice);
     }
 


### PR DESCRIPTION
# Description

Built off reclamm-2.1.

The original comment wasn't wrong, but slightly overstated and too specific, given that it's called in other contexts where the rounding is indeterminate (though even less important). Consistency is the real and sufficient reason for the original change.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
