### PR TITLE
[2.1] Fix exponential formula for daily price ratio update rate limit

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -577,6 +577,11 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         onlySwapFeeManagerOrGovernance(address(this))
         returns (uint256 actualPriceRatioUpdateStartTime)
     {
+        // Note: If the initial price range was 1,000 - 4,000, with a target price of 2,000, the raw ratio
+        // is 4 (`startPriceRatio` ~ 1.414). If the new fourth root is 1.682, the new `endPriceRatio` is 1.682^4 ~ 8.
+        // Since the centeredness remains constant, the new range would NOT be 1,000 - 8,000, but
+        // [C / sqrt(8), C * sqrt(8)], or about 707 - 5657.
+
         if (endPriceRatio < ReClammPoolFactoryLib.MIN_PRICE_RATIO) {
             revert PriceRatioBelowMin(endPriceRatio);
         } else if (endPriceRatio > ReClammPoolFactoryLib.MAX_PRICE_RATIO) {

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -764,10 +764,10 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
         uint256 updateDuration
     ) internal pure returns (uint256) {
         uint256 priceRatioMultiple = endPriceRatio > startPriceRatio
-            ? FixedPoint.divUp(endPriceRatio, startPriceRatio)
-            : FixedPoint.divUp(startPriceRatio, endPriceRatio);
+            ? endPriceRatio.divUp(startPriceRatio)
+            : startPriceRatio.divUp(endPriceRatio);
         uint256 exponent = FixedPoint.divUp(1 days, updateDuration);
-        return FixedPoint.powUp(priceRatioMultiple, exponent);
+        return priceRatioMultiple.powUp(exponent);
     }
 
     /// Using the pool balances to update the virtual balances is dangerous with an unlocked vault, since the balances

--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -614,20 +614,10 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
             revert PriceRatioDeltaBelowMin(priceRatioDelta);
         }
 
-        // Compute the rate of change, as a multiple of the present value per day. For example, if the initial price
-        // range was 1,000 - 4,000, with a target price of 2,000, the raw ratio would be 4 (`startPriceRatio` ~ 1.414).
-        // If the new fourth root is 1.682, the new `endPriceRatio` would be 1.682^4 ~ 8. Note that since the
-        // centeredness remains constant, the new range would NOT be 1,000 - 8,000, but [C / sqrt(8), C * sqrt(8)],
-        // or about 707 - 5657.
-        //
-        // If the `updateDuration is 1 day, the time periods cancel, so `actualDailyPriceRatioUpdateRate` is simply
-        // given by: `endPriceRatio` / `startPriceRatio`; or 8 / 4 = 2: doubling once per day.
-        // All values are 18-decimal fixed point.
-        uint256 actualDailyPriceRatioUpdateRate = endPriceRatio > startPriceRatio
-            ? FixedPoint.divUp(endPriceRatio * 1 days, startPriceRatio * updateDuration)
-            : FixedPoint.divUp(startPriceRatio * 1 days, endPriceRatio * updateDuration);
-
-        if (actualDailyPriceRatioUpdateRate > _MAX_DAILY_PRICE_RATIO_UPDATE_RATE) {
+        if (
+            _computeDailyPriceRatioUpdateRate(startPriceRatio, endPriceRatio, updateDuration) >
+            _MAX_DAILY_PRICE_RATIO_UPDATE_RATE
+        ) {
             revert PriceRatioUpdateTooFast();
         }
     }
@@ -756,6 +746,28 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
                 priceRatioUpdateEndTime
             )
         );
+    }
+
+    /**
+     * @notice Computes the effective daily price ratio update rate for a given start/end ratio and duration.
+     * @dev The rate is exponential: `(max(end, start) / min(end, start))^(1 day / updateDuration)`.
+     * All inputs and the return value are 18-decimal fixed point.
+     *
+     * @param startPriceRatio The price ratio at the start of the update
+     * @param endPriceRatio The price ratio at the end of the update
+     * @param updateDuration The duration of the update in seconds
+     * @return The effective daily price ratio change factor (>= FP(1))
+     */
+    function _computeDailyPriceRatioUpdateRate(
+        uint256 startPriceRatio,
+        uint256 endPriceRatio,
+        uint256 updateDuration
+    ) internal pure returns (uint256) {
+        uint256 priceRatioMultiple = endPriceRatio > startPriceRatio
+            ? FixedPoint.divUp(endPriceRatio, startPriceRatio)
+            : FixedPoint.divUp(startPriceRatio, endPriceRatio);
+        uint256 exponent = FixedPoint.divUp(1 days, updateDuration);
+        return FixedPoint.powUp(priceRatioMultiple, exponent);
     }
 
     /// Using the pool balances to update the virtual balances is dangerous with an unlocked vault, since the balances

--- a/contracts/test/ReClammPoolMock.sol
+++ b/contracts/test/ReClammPoolMock.sol
@@ -89,4 +89,12 @@ contract ReClammPoolMock is ReClammPool {
     ) external returns (uint256 startPriceRatio) {
         return _startPriceRatioUpdate(endPriceRatio, priceRatioUpdateStartTime, priceRatioUpdateEndTime);
     }
+
+    function computeDailyPriceRatioUpdateRate(
+        uint256 startPriceRatio,
+        uint256 endPriceRatio,
+        uint256 updateDuration
+    ) external pure returns (uint256) {
+        return _computeDailyPriceRatioUpdateRate(startPriceRatio, endPriceRatio, updateDuration);
+    }
 }

--- a/test/foundry/ReClammPool.t.sol
+++ b/test/foundry/ReClammPool.t.sol
@@ -503,6 +503,31 @@ contract ReClammPoolTest is BaseReClammTest {
         ReClammPool(pool).startPriceRatioUpdate(newPriceRatio, priceRatioUpdateStartTime, priceRatioUpdateEndTime);
     }
 
+    /**
+     * @notice Proves that the exponential daily-rate formula allows a 7× price ratio update over 3 days, while
+     * the old linear formula would have incorrectly rejected it.
+     * @dev Linear rate: (14/2) × (1/3) ≈ 2.333 > 2 — would fail.
+     * Exponential rate: (14/2)^(1/3) = 7^(1/3) ≈ 1.913 < 2 — passes.
+     */
+    function testDailyPriceRatioUpdateRateExponentialVsLinear() public view {
+        uint256 maxDailyPriceRatioUpdateRate = IReClammPool(pool)
+            .getReClammPoolImmutableData()
+            .maxDailyPriceRatioUpdateRate;
+
+        // The old linear formula: (max/min) × (1 day / duration).
+        // With startPriceRatio=2e18, endPriceRatio=14e18, duration=3 days this gives 7/3 ≈ 2.333.
+        uint256 linearRate = FixedPoint.divUp(14e18 * 1 days, 2e18 * 3 days);
+        assertGt(linearRate, maxDailyPriceRatioUpdateRate, "linear rate should exceed the limit");
+
+        // The new exponential formula: (max/min)^(1 day / duration).
+        // With startPriceRatio=2e18, endPriceRatio=14e18, duration=3 days this gives 7^(1/3) ≈ 1.913.
+        uint256 exponentialRate = ReClammPoolMock(pool).computeDailyPriceRatioUpdateRate(2e18, 14e18, 3 days);
+        assertLe(exponentialRate, maxDailyPriceRatioUpdateRate, "exponential rate should be within the limit");
+
+        // 7^(1/3) ≈ 1.91293e18, tolerance of 1e14 (0.01% precision).
+        assertApproxEqAbs(exponentialRate, 1.91293e18, 1e14, "exponential rate should be ~7^(1/3)");
+    }
+
     function testSetPriceRatioTooLow() public {
         uint256 newPriceRatio = ReClammPoolFactoryLib.MIN_PRICE_RATIO - 1;
         uint256 priceRatioUpdateStartTime = block.timestamp;


### PR DESCRIPTION
# Description

`startPriceRatioUpdate` was checking the speed of a price ratio update using a **linear** rate formula:

```
(endPriceRatio / startPriceRatio) × (1 day / updateDuration)
```

However, `ReClammMath.computeFourthRootPriceRatio` interpolates exponentially in fourth-root space, so the actual daily rate of change is:

```
(endPriceRatio / startPriceRatio) ^ (1 day / updateDuration)
```

The linear check could incorrectly reject valid updates (e.g. `2 → 14` over 3 days has an exponential daily rate of `7^(1/3) ≈ 1.91 < 2`, but a linear rate of `7/3 ≈ 2.33 > 2`).

The fix extracts the computation into a new internal helper `_computeDailyPriceRatioUpdateRate` and uses the correct exponential formula. An external wrapper is added to `ReClammPoolMock` and a Forge test documents both the failure of the linear check and the success of the exponential one for the concrete example above.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests have 100% code coverage
- [x] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->