### PR TITLE
[2.1] Remove unused constant

### DIFF
--- a/contracts/ReClammPool.sol
+++ b/contracts/ReClammPool.sol
@@ -48,8 +48,6 @@ contract ReClammPool is IReClammPool, BalancerPoolToken, PoolInfo, BasePoolAuthe
     // There is also a minimum delta, to keep the math well-behaved.
     uint256 internal constant _MIN_PRICE_RATIO_DELTA = 1e6;
 
-    uint256 internal constant _MAX_TOKEN_DECIMALS = 18;
-
     // solhint-disable-next-line immutable-vars-naming
     ReClammPoolHelper internal immutable _helper;
 


### PR DESCRIPTION
# Description

Must have gotten left behind when we added the pool helper to free up bytecode. Remove _MAX_TOKEN_DECIMALS from ReClammPool.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [X] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
