### PR TITLE
[2.1] Document intended `computeCurrentVirtualBalances` behavior

### DIFF
--- a/contracts/lib/ReClammMath.sol
+++ b/contracts/lib/ReClammMath.sol
@@ -349,6 +349,12 @@ library ReClammMath {
         // updated curve, providing the economic incentive for arbitrageurs to push the pool back toward range. At
         // typical operational configurations (daily shift exponent < 5%), the per-block VB change is much smaller than
         // the minimum round-trip swap fee (2 x 0.001%), making this economically neutral.
+        //
+        // Note: this freeze covers only the time-based VB evolution handled here (price-ratio updates and out-of-range
+        // decay). Proportional add and remove operations also scale VBs via the `onBeforeAddLiquidity` and
+        // `onBeforeRemoveLiquidity` hooks (up on add, down on remove), independently of this computation, and occur
+        // exactly once per operation regardless of block timing. That scaling preserves the Va/Vb ratio, and therefore
+        // also the centeredness and price ratio.
         if (lastTimestamp == currentTimestamp) {
             return (lastVirtualBalanceA, lastVirtualBalanceB, false);
         }

--- a/contracts/lib/ReClammMath.sol
+++ b/contracts/lib/ReClammMath.sol
@@ -340,7 +340,6 @@ library ReClammMath {
     ) internal view returns (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, bool changed) {
         uint32 currentTimestamp = block.timestamp.toUint32();
 
-
         // Per-block VB freeze: once any interaction in a block triggers VB recomputation and stores the result, all
         // subsequent interactions in the same block reuse the stored values. This is intentional. Without it, multiple
         // interactions within one block could each trigger recomputation at different effective durations, creating a

--- a/contracts/lib/ReClammMath.sol
+++ b/contracts/lib/ReClammMath.sol
@@ -340,15 +340,16 @@ library ReClammMath {
     ) internal view returns (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, bool changed) {
         uint32 currentTimestamp = block.timestamp.toUint32();
 
+
         // Per-block VB freeze: once any interaction in a block triggers VB recomputation and stores the result, all
         // subsequent interactions in the same block reuse the stored values. This is intentional. Without it, multiple
         // interactions within one block could each trigger recomputation at different effective durations, creating a
         // within-block manipulation surface. The consequence is that the first mover in each block (e.g., a MEV bot)
         // captures the VB shift that accumulated since the previous block. When the pool is out of range, this is the
-        // per-block increment of the re-centering mechanism: the arbitrageur trades against the stale price, earning
-        // the one-block drift as compensation. At typical operational configurations (daily shift exponent < 5%),
-        // the per-block VB change is much smaller than the minimum round-trip swap fee (2 x 0.001%), making this
-        // economically neutral.
+        // per-block increment of the re-centering mechanism: the first trade in each block executes against the
+        // updated curve, providing the economic incentive for arbitrageurs to push the pool back toward range. At
+        // typical operational configurations (daily shift exponent < 5%), the per-block VB change is much smaller than
+        // the minimum round-trip swap fee (2 x 0.001%), making this economically neutral.
         if (lastTimestamp == currentTimestamp) {
             return (lastVirtualBalanceA, lastVirtualBalanceB, false);
         }

--- a/contracts/lib/ReClammMath.sol
+++ b/contracts/lib/ReClammMath.sol
@@ -340,8 +340,15 @@ library ReClammMath {
     ) internal view returns (uint256 currentVirtualBalanceA, uint256 currentVirtualBalanceB, bool changed) {
         uint32 currentTimestamp = block.timestamp.toUint32();
 
-        // If the last timestamp is the same as the current timestamp, virtual balances were already reviewed in the
-        // current block.
+        // Per-block VB freeze: once any interaction in a block triggers VB recomputation and stores the result, all
+        // subsequent interactions in the same block reuse the stored values. This is intentional. Without it, multiple
+        // interactions within one block could each trigger recomputation at different effective durations, creating a
+        // within-block manipulation surface. The tradeoff is that the first mover in each block (e.g., a MEV bot)
+        // captures the VB shift that accumulated since the previous block. When the pool is out of range, this is the
+        // per-block increment of the re-centering mechanism: the arbitrageur trades against the stale price, earning
+        // the one-block drift as compensation. At typical operational configurations (daily shift exponent < 5%),
+        // the per-block VB change is much smaller than the minimum round-trip swap fee (2 x 0.001%), making this
+        // economically neutral.
         if (lastTimestamp == currentTimestamp) {
             return (lastVirtualBalanceA, lastVirtualBalanceB, false);
         }

--- a/contracts/lib/ReClammMath.sol
+++ b/contracts/lib/ReClammMath.sol
@@ -343,7 +343,7 @@ library ReClammMath {
         // Per-block VB freeze: once any interaction in a block triggers VB recomputation and stores the result, all
         // subsequent interactions in the same block reuse the stored values. This is intentional. Without it, multiple
         // interactions within one block could each trigger recomputation at different effective durations, creating a
-        // within-block manipulation surface. The tradeoff is that the first mover in each block (e.g., a MEV bot)
+        // within-block manipulation surface. The consequence is that the first mover in each block (e.g., a MEV bot)
         // captures the VB shift that accumulated since the previous block. When the pool is out of range, this is the
         // per-block increment of the re-centering mechanism: the arbitrageur trades against the stale price, earning
         // the one-block drift as compensation. At typical operational configurations (daily shift exponent < 5%),


### PR DESCRIPTION
# Description

Once any interaction in a block triggers VB recomputation and stores the result, all subsequent interactions in the same block reuse the stored values returned by `computeCurrentVirtualBalances`.

This is intentional. Without it, multiple interactions within one block could each trigger recomputation at different effective durations, creating a within-block manipulation surface. The consequence is that the first mover in each block (e.g., a MEV bot) captures the VB shift that accumulated since the previous block.

When the pool is out of range, this is the per-block increment of the re-centering mechanism: the arbitrageur trades against the stale price, earning the one-block drift as compensation. At typical operational configurations (daily shift exponent < 5%), the per-block VB change is much smaller than the minimum round-trip swap fee (2 x 0.001%), making this economically neutral.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [X] Documentation or wording changes
- [ ] Other

## Checklist:

- [X] The diff is legible and has no extraneous changes
- [N/A] Complex code has been commented, including external interfaces
- [N/A] Tests have 100% code coverage
- [X] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
