### PR TITLE
[2.1] Recalibration comments, and disabling recovery mode

### DIFF
--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -78,8 +78,11 @@ struct ReClammPoolImmutableData {
  * are withdrawals, raw and live balances will be out of sync until Recovery Mode is disabled.
  *
  * Normally pools that go into recovery do not come back, but it is possible. If so, the pool would operate post-
- * recovery with inflated virtual depth until the price drifts out of range (triggering a VB shift) or governance
- * forces recalibration by calling `setDailyPriceShiftExponent` or `setCenterednessMargin`.
+ * recovery with inflated virtual depth. Proportional withdrawals scale Ra and Rb by the same factor, leaving
+ * centeredness unchanged, so the out-of-range VB shift does not trigger immediately. Subsequent swaps do move
+ * centeredness asymmetrically, and will eventually drive the pool out of range, at which point the VB shift
+ * gradually recalibrates. `setDailyPriceShiftExponent` and `setCenterednessMargin` do not themselves recompute
+ * VBs from real balances; they only adjust their respective parameter.
  *
  * Base Pool:
  * @param balancesLiveScaled18 Token balances after paying yield fees, applying decimal scaling and rates

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -79,10 +79,10 @@ struct ReClammPoolImmutableData {
  *
  * Normally pools that go into recovery do not come back, but it is possible. If so, the pool would operate post-
  * recovery with inflated virtual depth. Proportional withdrawals scale Ra and Rb by the same factor, leaving
- * centeredness unchanged, so the out-of-range VB shift does not trigger immediately. Subsequent swaps do move
- * centeredness asymmetrically, and will eventually drive the pool out of range, at which point the VB shift
- * gradually recalibrates. `setDailyPriceShiftExponent` and `setCenterednessMargin` do not themselves recompute
- * VBs from real balances; they only adjust their respective parameter.
+ * centeredness unchanged, so the out-of-range VB shift does not trigger. Asymmetric swaps may gradually shift
+ * centeredness and eventually trigger recalibration, but this is not guaranteed. `setDailyPriceShiftExponent`
+ * and `setCenterednessMargin` do not recompute VBs from real balances; they only adjust their respective parameter.
+ * The only reliable recalibration path is `startPriceRatioUpdate` with a target that forces VB recomputation.
  *
  * Base Pool:
  * @param balancesLiveScaled18 Token balances after paying yield fees, applying decimal scaling and rates

--- a/contracts/interfaces/IReClammPool.sol
+++ b/contracts/interfaces/IReClammPool.sol
@@ -84,6 +84,11 @@ struct ReClammPoolImmutableData {
  * and `setCenterednessMargin` do not recompute VBs from real balances; they only adjust their respective parameter.
  * The only reliable recalibration path is `startPriceRatioUpdate` with a target that forces VB recomputation.
  *
+ * Note: disabling Recovery Mode on a ReClamm pool after withdrawals have occurred is not recommended. The inflated
+ * virtual balances cannot be fully corrected without a price ratio update, and the pool's swap curve will not price
+ * accurately until that recalibration is performed. Governance should treat Recovery Mode as one-way for this pool
+ * type.
+ *
  * Base Pool:
  * @param balancesLiveScaled18 Token balances after paying yield fees, applying decimal scaling and rates
  * @param tokenRates 18-decimal FP values for rate tokens (e.g., yield-bearing), or FP(1) for standard tokens


### PR DESCRIPTION
# Description

Recovery mode is really not recoverable for ReClamm pools (or at least will cause issues if the pool has been in recovery mode for any length of time, or is adjusting).

This is intended. While enabling recovery mode should never fail, there is no guarantee for any pool type that recovery mode can be disabled (especially ReClamms). There's no way to be sure that hooks, rate providers, possible external calls to other protocols, etc., will allow disabling recovery mode, or that the pool can operate safely after such an incident.

This PR just corrects a comment about "forcing recalibration," and underscores how recovery mode is (most likely) a one-way operation. ReClamm Pools don't actively *prevent* it, so we don't want to say that they "can't" be recovered, but we point out the issues with it.

## Type of change

- [ ] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Optimization: [ ] gas / [ ] bytecode
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [ ] The diff is legible and has no extraneous changes
- [ ] Complex code has been commented, including external interfaces
- [ ] Tests have 100% code coverage
- [ ] The base branch is either `main`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
